### PR TITLE
FluentEvent::SourceF was defined twice. Changed second FluentEvent::Sourc

### DIFF
--- a/loggr-php/loggr.php
+++ b/loggr-php/loggr.php
@@ -167,7 +167,7 @@ class FluentEvent
 		return $this;
 	}
 
-	public function SourceF()
+	public function UserF()
 	{
 		$args = func_get_args();
 	    return $this->User(vsprintf(array_shift($args), array_values($args)));


### PR DESCRIPTION
FluentEvent::SourceF was defined twice. Changed second FluentEvent::SourceF to FluentEvent::UserF.
